### PR TITLE
Refactored page title from controller into view

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,26 +1,20 @@
 class PagesController < ApplicationController
 
   def index
-    @title = "Home"
   end
 
   def about
-    @title = "About"
   end
 
   def alumni
-  	@title = "Alumni"
   end
 
   def terms
-    @title = "Terms of Service"
   end
 
   def future
-    @title = "Future Directions"
   end
 
   def demo
-    @title = "Demo"
   end
 end

--- a/app/controllers/prisms_controller.rb
+++ b/app/controllers/prisms_controller.rb
@@ -10,7 +10,6 @@ class PrismsController < ApplicationController
 
   def index
     @prisms = Prism.paginate(:page => params[:page], :per_page => 10)
-    @title = "Browse"
 
     for prism in Prism.all
       if !prism.unlisted
@@ -25,7 +24,6 @@ class PrismsController < ApplicationController
   end
 
   def highlight
-    @title = "Highlight"
   end
 
   def highlight_post

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,6 @@ class UsersController < ApplicationController
     if @user != nil
     	@prisms = @user.prisms
     	@highlighted_prisms = @user.word_markings.map(&:prism_id).uniq
-	    @title = "myprisms"
     else
     	redirect_to :home
     	flash[:error] ="Sign in first!"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,7 @@
 module ApplicationHelper
 
-  def title
-    base_title = "Prism"
-    if @title.nil?
-      base_title
-    else
-      "#{base_title} | #{@title}"
-    end
+  def title(page_title)
+    content_for(:title) { " | #{page_title}" }
   end
 
   def page_id

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
 <!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
-  <title><%= title %></title>
+  <title>Prism <%= yield :title %></title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="icon" type="image/png" href="<%= asset_path('favicon.png') %>">

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,3 +1,4 @@
+<% title "About" %>
 <div class="callout teacher-notice">
   <h3 id="note-to-teachers" >A Note to Teachers</h3>
 

--- a/app/views/pages/alumni.html.erb
+++ b/app/views/pages/alumni.html.erb
@@ -1,3 +1,5 @@
+<% title "Alumni" %>
+
 <div class="page-margin">
   <div id="page-content">
     <h1><%= t 'alumni.alumni_title' %></h1> 

--- a/app/views/pages/demo.html.erb
+++ b/app/views/pages/demo.html.erb
@@ -1,3 +1,4 @@
+<% title "Demo" %>
 <div class="page-margin">
   <div id="page-content">
     <h1><center>Click the Play Button to View the Prism Tutorial!</center></h1> 

--- a/app/views/pages/future.html.erb
+++ b/app/views/pages/future.html.erb
@@ -1,3 +1,4 @@
+<% title "Future Directions" %>
 <div class="page-margin">
   <div id="page-content">
     <h1>Future Directions</h1> 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,3 +1,4 @@
+<% title "Home" %>
 <div id="buttons">
   <span><%= link_to 'Demo', demo_path, :class => 'demo' %></span>
   <span><%= link_to 'Create', new_prism_path, :class => 'create' %></span>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,3 +1,4 @@
+<% title "Terms of Service" %>
 <div class="page-margin">
   <div id="page-content">
     <h1>Terms of Service</h1> 

--- a/app/views/prisms/highlight.html.erb
+++ b/app/views/prisms/highlight.html.erb
@@ -1,3 +1,4 @@
+<% title "Highlight" %>
 <% content_for :extra_head do %>
   <script type="text/javascript" charset="utf-8">
 $(setup_highlight);

--- a/app/views/prisms/index.html.erb
+++ b/app/views/prisms/index.html.erb
@@ -1,3 +1,5 @@
+<% title "Browse" %>
+
 <%= link_to 'New prism', new_prism_path, :id => 'new-prism', :class => 'button' %>
 
 <h1>Browse Prisms</h1>

--- a/app/views/prisms/new.html.erb
+++ b/app/views/prisms/new.html.erb
@@ -1,3 +1,4 @@
+<% title "New Prism" %>
 <h1>New Prism</h1>
 
 <%= form_for(@prism) do |f| %>

--- a/app/views/prisms/visualize.html.erb
+++ b/app/views/prisms/visualize.html.erb
@@ -1,3 +1,4 @@
+<% title "Visualise" %>
 <div style="display:none;">view updated</div>
 <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 <script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,5 @@
+<% title "My Prisms" %>
+
 <%= link_to 'New prism', new_prism_path, :class => 'button', :id => 'new-prism' %>
   <h1>myPrisms (<%= @user.email %>)</h1>
   <%= image_tag(avatar_url(current_user), :class => "avatar") %>


### PR DESCRIPTION
I noticed that page titles were being set in the controller methods.  It is generally better practice (in keeping with MVC) to set page titles in the view, so I refactored.  There's now a `title` helper that can be used in views to set the page title.